### PR TITLE
feature: Added multilevel prefixes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,8 +3,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
     <php>
         <env name="KERNEL_CLASS" value="AppKernel" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
          bootstrap="tests/bootstrap.php"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnPhpunitDeprecations="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
     <php>
         <env name="KERNEL_CLASS" value="AppKernel" />

--- a/src/Builder/QueryParamUrlBuilder.php
+++ b/src/Builder/QueryParamUrlBuilder.php
@@ -23,7 +23,6 @@ final class QueryParamUrlBuilder implements UrlBuilder
         $parsedUrl = parse_url($request->getUri());
         parse_str($parsedUrl['query'] ?? '', $query);
         /** @var array<string, string|array<string, string>> $query */
-
         $prefix = $sorter->getPrefix();
         foreach ($sorter->getFields() as $fieldName) {
             if (null === $prefix) {

--- a/src/Builder/QueryParamUrlBuilder.php
+++ b/src/Builder/QueryParamUrlBuilder.php
@@ -6,6 +6,7 @@ namespace Sorter\Builder;
 
 use Sorter\Sort;
 use Sorter\Sorter;
+use Sorter\Util\QueryArrayExtractor;
 use Symfony\Component\HttpFoundation\Request;
 
 final class QueryParamUrlBuilder implements UrlBuilder
@@ -21,15 +22,24 @@ final class QueryParamUrlBuilder implements UrlBuilder
 
         $parsedUrl = parse_url($request->getUri());
         parse_str($parsedUrl['query'] ?? '', $query);
+        /** @var array<string, string|array<string, string>> $query */
 
         $prefix = $sorter->getPrefix();
         foreach ($sorter->getFields() as $fieldName) {
-            if (null !== $prefix && isset($query[$prefix][$fieldName])) {
-                unset($query[$prefix][$fieldName]);
+            if (null === $prefix) {
+                unset($query[$fieldName]);
+
                 continue;
             }
 
-            unset($query[$fieldName]);
+            /** @var array<string, string|array<string, string>> $queryPart */
+            $queryPart = &$query;
+            foreach (QueryArrayExtractor::extractFullPathFromPrefix($prefix) as $path) {
+                /** @var array<string, string|array<string, string>> $queryPart */
+                $queryPart = &$queryPart[$path];
+            }
+
+            unset($queryPart[$fieldName]);
         }
 
         if (null === $prefix) {
@@ -37,8 +47,12 @@ final class QueryParamUrlBuilder implements UrlBuilder
             $query[$field] = $direction;
         } else {
             /** @var array<string, array<string, string>> $query */
-            $query[$prefix] = $query[$prefix] ?? [];
-            $query[$prefix][$field] = $direction;
+            $queryPart = &$query;
+            foreach (QueryArrayExtractor::extractFullPathFromPrefix($prefix) as $path) {
+                $queryPart = &$queryPart[$path];
+            }
+
+            $queryPart[$field] = $direction;
         }
 
         return ($parsedUrl['path'] ?? '').'?'.http_build_query($query);

--- a/src/Exception/CannotExtractException.php
+++ b/src/Exception/CannotExtractException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sorter\Exception;
+
+
+final class CannotExtractException extends \InvalidArgumentException implements SorterException
+{
+}

--- a/src/Exception/CannotExtractException.php
+++ b/src/Exception/CannotExtractException.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Sorter\Exception;
+declare(strict_types=1);
 
+namespace Sorter\Exception;
 
 final class CannotExtractException extends \InvalidArgumentException implements SorterException
 {

--- a/src/Sorter.php
+++ b/src/Sorter.php
@@ -139,8 +139,8 @@ final class Sorter
 
         $fields = [];
         foreach ($this->getFields() as $field) {
-            if ($request->query->has($field) && $value = $request->query->getString($field)) {
-                $fields[$field] = $value;
+            if (null !== ($value = $request->query->get($field))) {
+                $fields[$field] = (string) $value;
             }
         }
 

--- a/src/Sorter.php
+++ b/src/Sorter.php
@@ -100,10 +100,10 @@ final class Sorter
             parse_str($this->prefix, $result);
 
             /** @psalm-suppress RedundantCondition */
-            while (is_array($result)) {
+            while (\is_array($result)) {
                 $key = array_key_first($result);
 
-                if (!(is_string($key) && isset($values[$key]) && is_array($result[$key]))) {
+                if (!(\is_string($key) && isset($values[$key]) && \is_array($result[$key]))) {
                     break;
                 }
                 $values = $values[$key];
@@ -140,7 +140,7 @@ final class Sorter
             parse_str($this->prefix, $result);
             $key = array_key_first($result);
 
-            if (is_string($key)) {
+            if (\is_string($key)) {
                 /** @psalm-suppress MixedArgumentTypeCoercion */
                 $this->handle([$key => $request->query->all($key)]);
             }

--- a/src/Util/QueryArrayExtractor.php
+++ b/src/Util/QueryArrayExtractor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sorter\Util;
 
 use Sorter\Exception\CannotExtractException;

--- a/src/Util/QueryArrayExtractor.php
+++ b/src/Util/QueryArrayExtractor.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sorter\Util;
+
+use Sorter\Exception\CannotExtractException;
+
+final class QueryArrayExtractor
+{
+    /**
+     * @param array<string, string>|array<string, array<string, string>>|array<string, array<string, array<string, string>>> $queryArray
+     */
+    public static function extract(?array $queryArray, ?string $prefix): array
+    {
+        if (null === $prefix) {
+            return $queryArray ?? [];
+        }
+
+        return array_reduce(
+            self::extractFullPathFromPrefix($prefix),
+            static function (array $carry, string $part): array {
+                /** @psalm-suppress MixedReturnStatement */
+                return $carry[$part] ?? [];
+            },
+            $queryArray ?? [],
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function extractFullPathFromPrefix(?string $prefix): array
+    {
+        if (null === $prefix) {
+            return [];
+        }
+
+        $matches = [];
+        if (!(preg_match('#^(?<outer>[^\[\]]+)(\[([^\[\]]+)])*$#', $prefix, $matches) > 0)) {
+            throw new CannotExtractException('Invalid prefix format: '.$prefix);
+        }
+
+        $prefixParts = [$matches['outer']];
+        if (preg_match_all('#\[(?<enclosed>[^\[\]]+)]#', $prefix, $matches) > 0) {
+            $prefixParts = [...$prefixParts, ...$matches['enclosed']];
+        }
+
+        return $prefixParts;
+    }
+}

--- a/tests/Builder/QueryParamUrlBuilderTest.php
+++ b/tests/Builder/QueryParamUrlBuilderTest.php
@@ -34,6 +34,7 @@ final class QueryParamUrlBuilderTest extends TestCase
 
         $this->assertSame('/foo/bar?prefix%5Bb%5D=ASC&baz=qux', $urlBuilder->generateFromRequest($sorter, $request, 'b'));
     }
+
     public function testItGeneratesWithDoublePrefix(): void
     {
         /** @var Request&MockObject $request */

--- a/tests/Builder/QueryParamUrlBuilderTest.php
+++ b/tests/Builder/QueryParamUrlBuilderTest.php
@@ -34,6 +34,26 @@ final class QueryParamUrlBuilderTest extends TestCase
 
         $this->assertSame('/foo/bar?prefix%5Bb%5D=ASC&baz=qux', $urlBuilder->generateFromRequest($sorter, $request, 'b'));
     }
+    public function testItGeneratesWithDoublePrefix(): void
+    {
+        /** @var Request&MockObject $request */
+        $request = $this->createMock(Request::class);
+        $request->expects($this->once())->method('getUri')->willReturn('/foo/bar?prefix[second][a]=ASC&baz=qux');
+
+        /** @var Sort&MockObject $sort */
+        $sort = $this->createMock(Sort::class);
+        $sort->expects($this->once())->method('has')->with('b')->willReturn(false);
+
+        /** @var Sorter&MockObject $sorter */
+        $sorter = $this->createMock(Sorter::class);
+        $sorter->expects($this->once())->method('getPrefix')->willReturn('prefix[second]');
+        $sorter->expects($this->once())->method('getFields')->willReturn(['a', 'b']);
+        $sorter->method('getCurrentSort')->willReturn($sort);
+
+        $urlBuilder = new QueryParamUrlBuilder();
+
+        $this->assertSame('/foo/bar?prefix%5Bsecond%5D%5Bb%5D=ASC&baz=qux', $urlBuilder->generateFromRequest($sorter, $request, 'b'));
+    }
 
     #[DataProvider('providesRequests')]
     public function testItGeneratesFromRequest(bool $hasCurrentSort): void

--- a/tests/Extension/Symfony/Fixtures/Controller/DoublePrefixArraySortController.php
+++ b/tests/Extension/Symfony/Fixtures/Controller/DoublePrefixArraySortController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sorter\Tests\Extension\Symfony\Fixtures\Controller;
+
+use Sorter\Definition;
+use Sorter\Sorter;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+
+#[AsController]
+final class DoublePrefixArraySortController extends AbstractArraySortController
+{
+    protected function getSorterDefinition(): Definition
+    {
+        $parentDefinition = parent::getSorterDefinition();
+
+        return new class($parentDefinition) implements Definition {
+            public function __construct(private readonly Definition $parentDefinition)
+            {
+            }
+
+            public function buildSorter(Sorter $sorter): void
+            {
+                $this->parentDefinition->buildSorter($sorter);
+
+                $sorter->setPrefix('prefix[second]');
+            }
+        };
+    }
+}

--- a/tests/Extension/Symfony/Fixtures/app/AppKernel.php
+++ b/tests/Extension/Symfony/Fixtures/app/AppKernel.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Sorter\Tests\Extension\Symfony\Fixtures\Controller\ArraySortController;
+use Sorter\Tests\Extension\Symfony\Fixtures\Controller\DoublePrefixArraySortController;
 use Sorter\Tests\Extension\Symfony\Fixtures\Controller\PrefixArraySortController;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,6 +44,12 @@ final class AppKernel extends Kernel
             ->setAutoconfigured(true)
             ->setAutowired(true)
             ->addTag('controller.service_arguments');
+
+        $container
+            ->setDefinition(DoublePrefixArraySortController::class, new Definition(DoublePrefixArraySortController::class))
+            ->setAutoconfigured(true)
+            ->setAutowired(true)
+            ->addTag('controller.service_arguments');
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
@@ -54,6 +61,9 @@ final class AppKernel extends Kernel
         $routes
             ->add('array-sort-prefix', '/array-sort-prefix')
                 ->controller(PrefixArraySortController::class);
+        $routes
+            ->add('array-sort-double-prefix', '/array-sort-double-prefix')
+                ->controller(DoublePrefixArraySortController::class);
     }
 
     public function getProjectDir(): string

--- a/tests/Extension/Symfony/Functionnal/PrefixArraySortTest.php
+++ b/tests/Extension/Symfony/Functionnal/PrefixArraySortTest.php
@@ -13,7 +13,7 @@ final class PrefixArraySortTest extends WebTestCase
     public function testItDisplaySortedTable(string $queryString, array $titles, array $links, string $clickedLink, string $expectedUrl): void
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/array-sort-prefix'.$queryString);
+        $crawler = $client->request('GET', '/array-sort-prefix' . $queryString);
         $this->assertResponseIsSuccessful();
 
         foreach ($titles as $i => $title) {
@@ -91,6 +91,92 @@ final class PrefixArraySortTest extends WebTestCase
             ['a' => 'DESC'],
             'C',
             '/array-sort-prefix?prefix%5Bc%5D=ASC',
+        ];
+    }
+
+
+    #[DataProvider('providesSortParamsAndTitleWithDoublePrefix')]
+    public function testItDisplaySortedTableWithDoublePrefix(string $queryString, array $titles, array $links, string $clickedLink, string $expectedUrl): void
+    {
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/array-sort-double-prefix' . $queryString);
+        $this->assertResponseIsSuccessful();
+
+        foreach ($titles as $i => $title) {
+            $this->assertStringContainsString(
+                $title,
+                $crawler->filter('tbody > tr:nth-child('.($i + 1).')')->text(),
+            );
+        }
+
+        foreach ($links as $column => $order) {
+            $this->assertStringContainsString(
+                '?'.urlencode('prefix[second]['.$column.']').'='.$order,
+                $crawler->filter('thead th[data-col='.$column.'] a')->attr('href'),
+            );
+        }
+
+        $client->clickLink($clickedLink);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame($expectedUrl, $client->getRequest()->getRequestUri());
+    }
+
+    public static function providesSortParamsAndTitleWithDoublePrefix(): iterable
+    {
+        yield 'Default order (double prefix)' => [
+            '',
+            [
+                'The third title',
+                'The fourth title',
+                'The second title',
+                'The fifth title',
+                'The first title',
+            ],
+            ['c' => 'DESC', 'a' => 'ASC'],
+            'C',
+            '/array-sort-double-prefix?prefix%5Bsecond%5D%5Bc%5D=DESC',
+        ];
+
+        yield 'Title Ascending (First Column) (double prefix)' => [
+            '?prefix[second][title]=ASC',
+            [
+                'The fifth title',
+                'The first title',
+                'The fourth title',
+                'The second title',
+                'The third title',
+            ],
+            ['title' => 'DESC', 'a' => 'ASC'],
+            'Title',
+            '/array-sort-double-prefix?prefix%5Bsecond%5D%5Btitle%5D=DESC',
+        ];
+
+        yield 'Title Descending (First Column) (double prefix)' => [
+            '?prefix[second][title]=DESC',
+            [
+                'The third title',
+                'The second title',
+                'The fourth title',
+                'The first title',
+                'The fifth title',
+            ],
+            ['title' => 'ASC'],
+            'Title',
+            '/array-sort-double-prefix?prefix%5Bsecond%5D%5Btitle%5D=ASC',
+        ];
+
+        yield 'Integer column Ascending (double prefix)' => [
+            '?prefix[second][a]=ASC',
+            [
+                'The first title',
+                'The second title',
+                'The third title',
+                'The fourth title',
+                'The fifth title',
+            ],
+            ['a' => 'DESC'],
+            'C',
+            '/array-sort-double-prefix?prefix%5Bsecond%5D%5Bc%5D=ASC',
         ];
     }
 }

--- a/tests/Extension/Symfony/Functionnal/PrefixArraySortTest.php
+++ b/tests/Extension/Symfony/Functionnal/PrefixArraySortTest.php
@@ -13,7 +13,7 @@ final class PrefixArraySortTest extends WebTestCase
     public function testItDisplaySortedTable(string $queryString, array $titles, array $links, string $clickedLink, string $expectedUrl): void
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/array-sort-prefix' . $queryString);
+        $crawler = $client->request('GET', '/array-sort-prefix'.$queryString);
         $this->assertResponseIsSuccessful();
 
         foreach ($titles as $i => $title) {
@@ -94,12 +94,11 @@ final class PrefixArraySortTest extends WebTestCase
         ];
     }
 
-
     #[DataProvider('providesSortParamsAndTitleWithDoublePrefix')]
     public function testItDisplaySortedTableWithDoublePrefix(string $queryString, array $titles, array $links, string $clickedLink, string $expectedUrl): void
     {
         $client = $this->createClient();
-        $crawler = $client->request('GET', '/array-sort-double-prefix' . $queryString);
+        $crawler = $client->request('GET', '/array-sort-double-prefix'.$queryString);
         $this->assertResponseIsSuccessful();
 
         foreach ($titles as $i => $title) {

--- a/tests/SorterTest.php
+++ b/tests/SorterTest.php
@@ -69,6 +69,16 @@ final class SorterTest extends TestCase
         $this->assertSame('ASC', $this->sorter->getCurrentSort()->getDirection('a'));
     }
 
+    public function testHandlesArrayWithDoublePrefix(): void
+    {
+        $this->sorter->setPrefix('prefix[second_prefix]');
+        $this->sorter->add('a', '[a]');
+        $this->sorter->add('b', '[b]');
+        $this->sorter->handle(['prefix' => ['second_prefix' => ['a' => 'ASC']]]);
+
+        $this->assertSame('ASC', $this->sorter->getCurrentSort()->getDirection('a'));
+    }
+
     public function testHandleThrowsWithBadValue(): void
     {
         $this->expectException(ScalarExpectedException::class);
@@ -102,6 +112,21 @@ final class SorterTest extends TestCase
         $this->sorter->add('b', '[b]');
 
         $request->query = new InputBag(['prefix' => ['a' => 'ASC']]);
+
+        $this->sorter->handleRequest($request);
+
+        $this->assertSame('ASC', $this->sorter->getCurrentSort()->getDirection('a'));
+    }
+
+    public function testHandlesRequestWithDoublePrefix(): void
+    {
+        /** @var Request&MockObject $request */
+        $request = $this->createMock(Request::class);
+        $this->sorter->setPrefix('prefix[second_prefix]');
+        $this->sorter->add('a', '[a]');
+        $this->sorter->add('b', '[b]');
+
+        $request->query = new InputBag(['prefix' => ['second_prefix' => ['a' => 'ASC']]]);
 
         $this->sorter->handleRequest($request);
 

--- a/tests/Util/QueryArrayExtractorTest.php
+++ b/tests/Util/QueryArrayExtractorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Sorter\Tests\Util;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sorter\Exception\CannotExtractException;
+use Sorter\Util\QueryArrayExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class QueryArrayExtractorTest extends TestCase
+{
+    #[DataProvider('extractDataProvider')]
+    public function testExtract(?array $queryArray, ?string $prefix, array $expected): void
+    {
+        $this->assertSame($expected, QueryArrayExtractor::extract($queryArray, $prefix));
+    }
+
+    public static function extractDataProvider(): iterable
+    {
+        yield 'flat query' => [
+            'queryArray' => ['a' => 'foo', 'b' => 'bar'],
+            'prefix' => null,
+            'expected' => ['a' => 'foo', 'b' => 'bar'],
+        ];
+
+        yield 'flat query, empty value' => [
+            'queryArray' => null,
+            'prefix' => null,
+            'expected' => [],
+        ];
+
+        yield 'prefixed query' => [
+            'queryArray' => ['prefix' => ['a' => 'foo', 'b' => 'bar']],
+            'prefix' => 'prefix',
+            'expected' => ['a' => 'foo', 'b' => 'bar'],
+        ];
+
+        yield 'prefixed query, empty value' => [
+            'queryArray' => null,
+            'prefix' => 'prefix',
+            'expected' => [],
+        ];
+
+        yield 'double prefixed query' => [
+            'queryArray' => ['prefix' => ['second' => ['a' => 'foo', 'b' => 'bar']]],
+            'prefix' => 'prefix[second]',
+            'expected' => ['a' => 'foo', 'b' => 'bar'],
+        ];
+
+        yield 'double prefixed query, empty value' => [
+            'queryArray' => ['prefix' => null],
+            'prefix' => 'prefix[second]',
+            'expected' => [],
+        ];
+
+        yield 'triple prefixed query' => [
+            'queryArray' => ['prefix' => ['second' => [ 'third' => ['a' => 'foo', 'b' => 'bar']]]],
+            'prefix' => 'prefix[second][third]',
+            'expected' => ['a' => 'foo', 'b' => 'bar'],
+        ];
+    }
+
+    #[DataProvider('extractThrowsDataProvider')]
+    public function testItThrowsWhenExtractParamsInvalid(array $queryArray, ?string $prefix, string $path): void
+    {
+        $this->expectException(CannotExtractException::class);
+        $this->expectExceptionMessage('Invalid prefix format: []');
+
+        QueryArrayExtractor::extract($queryArray, $prefix);
+    }
+
+    public static function extractThrowsDataProvider(): iterable
+    {
+        yield 'InvalidPrefix' => [
+            'queryArray' => [],
+            'prefix' => '[]',
+            'path' => '',
+        ];
+    }
+}

--- a/tests/Util/QueryArrayExtractorTest.php
+++ b/tests/Util/QueryArrayExtractorTest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sorter\Tests\Util;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 use Sorter\Exception\CannotExtractException;
 use Sorter\Util\QueryArrayExtractor;
-use PHPUnit\Framework\TestCase;
 
 final class QueryArrayExtractorTest extends TestCase
 {
@@ -54,7 +56,7 @@ final class QueryArrayExtractorTest extends TestCase
         ];
 
         yield 'triple prefixed query' => [
-            'queryArray' => ['prefix' => ['second' => [ 'third' => ['a' => 'foo', 'b' => 'bar']]]],
+            'queryArray' => ['prefix' => ['second' => ['third' => ['a' => 'foo', 'b' => 'bar']]]],
             'prefix' => 'prefix[second][third]',
             'expected' => ['a' => 'foo', 'b' => 'bar'],
         ];


### PR DESCRIPTION
This PR allows to use nested query param prefix, ex: `sort[user][post][title]=ASC`