### PR TITLE
feat(applier): Added SqlApplier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,19 +9,20 @@
         "symfony/http-foundation": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.5|^3.0",
-        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
-        "symfony/property-access": "^5.4|^6.0|^7.0",
-        "twig/twig": "^3.0.0",
-        "vimeo/psalm": "^6.9",
-        "phpunit/phpunit": "^10.5.40",
         "dg/bypass-finals": "^1.9",
+        "doctrine/orm": "^2.5|^3.0",
         "friendsofphp/php-cs-fixer": "^3.72",
-        "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "infection/infection": "^0.28.1",
+        "phpmyadmin/sql-parser": "^5.11",
+        "phpunit/phpunit": "^10.5.40",
         "symfony/browser-kit": "^5.4|^6.0|^7.0",
+        "symfony/css-selector": "^5.4|^6.0|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/monolog-bundle": "^3.10",
-        "symfony/css-selector": "^5.4|^6.0|^7.0"
+        "symfony/property-access": "^5.4|^6.0|^7.0",
+        "symfony/twig-bundle": "^5.4|^6.0|^7.0",
+        "twig/twig": "^3.0.0",
+        "vimeo/psalm": "^6.9"
     },
     "autoload": {
         "psr-4": {

--- a/examples/basic-sql-sort.php
+++ b/examples/basic-sql-sort.php
@@ -1,0 +1,37 @@
+<?php
+
+use Sorter\Applier\SqlApplier;
+use Sorter\Sort;
+use Sorter\SorterFactory;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+
+$sql = 'SELECT p, COUNT(p.comments) FROM post p INNER JOIN p.comments comments GROUP BY p.id';
+
+
+$factory = new SorterFactory([new SqlApplier()]);
+$sorter = $factory->createSorter()
+    ->add('title', 'p.title')
+    ->add('date', 'p.date')
+    ->add('weight', 'p.weight')
+    ->add('comments', 'COUNT(p.comments)')
+    ->addDefault('date', Sort::ASC);
+
+
+echo "\n\n Default sort (Ascending date):\n";
+$sorter->handle([]);
+$sortedSql = $sorter->sort($sql);
+echo " ", $sortedSql, "\n";
+
+
+echo "\n\n Single column sort (Ascending title):\n";
+$sorter->handle(['title' => 'ASC']);
+$sortedSql = $sorter->sort($sql);
+echo " ", $sortedSql, "\n";
+
+
+echo "\n\n Double column sort (Ascending Weight, Ascending title):\n";
+$sorter->handle(['weight' => 'ASC', 'title' => 'ASC']);
+$sortedSql = $sorter->sort($sql);
+echo " ", $sortedSql, "\n";

--- a/src/Applier/SqlApplier.php
+++ b/src/Applier/SqlApplier.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sorter\Applier;
+
+use PhpMyAdmin\SqlParser\Components\Expression;
+use PhpMyAdmin\SqlParser\Components\OrderKeyword;
+use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Statements\SelectStatement;
+use Sorter\Exception\IncompatibleApplierException;
+use Sorter\Exception\IncompatibleQueryException;
+use Sorter\Exception\PackageMissingException;
+use Sorter\Sort;
+
+final class SqlApplier implements SortApplier
+{
+    #[\Override]
+    public function apply(Sort $sort, mixed $data, array $options = []): mixed
+    {
+        if (!class_exists(Parser::class)) {
+            // @codeCoverageIgnoreStart
+            // @infection-ignore-all
+            throw new PackageMissingException('phpmyadmin/sql-parser', __CLASS__);
+            // @codeCoverageIgnoreEnd
+        }
+
+        if (!$this->supports($data)) {
+            throw new IncompatibleApplierException('SQL String', $data);
+        }
+
+        /** @var string $data */
+        $parser = new Parser($data, false);
+        $selectStatement = $parser->statements[0];
+        if (!$selectStatement instanceof SelectStatement) {
+            throw new IncompatibleQueryException();
+        }
+
+        foreach ($sort->getFields() as $field) {
+            $path = $sort->getPath($field);
+            $newOrderKeyword = new OrderKeyword(new Expression($path), strtoupper($sort->getDirection($field)));
+
+            foreach ($selectStatement->order ?? [] as $i => $orderKeyword) {
+                if ($newOrderKeyword->expr->expr === $orderKeyword->expr->expr) {
+                    $selectStatement->order[$i] = $newOrderKeyword;
+
+                    continue 2;
+                }
+            }
+
+            $selectStatement->order[] = $newOrderKeyword;
+        }
+
+        return $selectStatement->build();
+    }
+
+    #[\Override]
+    public function supports(mixed $data): bool
+    {
+        if (!\is_string($data)) {
+            return false;
+        }
+
+        $parser = new Parser($data, false);
+
+        return 0 !== \count($parser->statements);
+    }
+}

--- a/src/Exception/IncompatibleQueryException.php
+++ b/src/Exception/IncompatibleQueryException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sorter\Exception;
+
+final class IncompatibleQueryException extends \InvalidArgumentException implements SorterException
+{
+}

--- a/src/Exception/PackageMissingException.php
+++ b/src/Exception/PackageMissingException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sorter\Exception;
+
+/**
+ * @codeCoverageIgnore This exception is thrown when a composer package is missing. It is not possible to test this.
+ *
+ * @infection-ignore-all
+ */
+final class PackageMissingException extends \RuntimeException implements SorterException
+{
+    public function __construct(string $package, string $featureRequiring)
+    {
+        parent::__construct(
+            \sprintf(
+                'The "%s" package is required to use the "%s" feature.',
+                $package,
+                $featureRequiring,
+            ),
+        );
+    }
+}

--- a/src/Extension/Symfony/Bundle/Resources/config/services.php
+++ b/src/Extension/Symfony/Bundle/Resources/config/services.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Sorter\Applier\ArrayApplier;
 use Sorter\Applier\DoctrineORMApplier;
+use Sorter\Applier\SqlApplier;
 use Sorter\Builder\QueryParamUrlBuilder;
 use Sorter\Builder\UrlBuilder;
 use Sorter\Extension\Twig\SortExtension;
@@ -24,6 +25,10 @@ return static function (ContainerConfigurator $container): void {
 
     $services
         ->set(DoctrineORMApplier::class)
+            ->tag('sorter.applier');
+
+    $services
+        ->set(SqlApplier::class)
             ->tag('sorter.applier');
 
     $services

--- a/src/Util/QueryArrayExtractor.php
+++ b/src/Util/QueryArrayExtractor.php
@@ -30,12 +30,8 @@ final class QueryArrayExtractor
     /**
      * @return string[]
      */
-    public static function extractFullPathFromPrefix(?string $prefix): array
+    public static function extractFullPathFromPrefix(string $prefix): array
     {
-        if (null === $prefix) {
-            return [];
-        }
-
         $matches = [];
         if (!(preg_match('#^(?<outer>[^\[\]]+)(\[([^\[\]]+)])*$#', $prefix, $matches) > 0)) {
             throw new CannotExtractException('Invalid prefix format: '.$prefix);

--- a/tests/Applier/SqlApplierTest.php
+++ b/tests/Applier/SqlApplierTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sorter\Tests\Applier;
+
+use PHPUnit\Framework\TestCase;
+use Sorter\Applier\SqlApplier;
+use Sorter\Exception\IncompatibleApplierException;
+use Sorter\Exception\IncompatibleQueryException;
+use Sorter\Sort;
+
+final class SqlApplierTest extends TestCase
+{
+    private readonly SqlApplier $applier;
+
+    protected function setUp(): void
+    {
+        $this->applier = new SqlApplier();
+    }
+
+    public function testItSupportsSql(): void
+    {
+        $this->assertTrue($this->applier->supports('SELECT * FROM users'));
+        $this->assertTrue($this->applier->supports('SELECT name, COUNT(id) FROM users GROUP BY name ORDER BY name'));
+        $this->assertTrue($this->applier->supports('SELECT users.name, COUNT(users.id) FROM users INNER JOIN profile ON profile.user_id = users.id GROUP BY users.name ORDER BY ARRAY_POSITION(ARRAY[\'foo\', \'bar\', \'baz\'], users.name)'));
+    }
+
+    public function testItDoesNotSupportNonSql(): void
+    {
+        $this->assertFalse($this->applier->supports(new \stdClass()));
+        $this->assertFalse($this->applier->supports([]));
+        $this->assertFalse($this->applier->supports('This is not a SQL query'));
+        $this->assertFalse($this->applier->supports('êêê'));
+    }
+
+    public function testItThrowsInIncompatibleData(): void
+    {
+        $this->expectException(IncompatibleApplierException::class);
+
+        $this->applier->apply($this->createMock(Sort::class), []);
+    }
+
+    public function testItThrowsInIncompatibleQuery(): void
+    {
+        $this->expectException(IncompatibleQueryException::class);
+
+        $this->applier->apply(
+            $this->createMock(Sort::class),
+            'WITH RECURSIVE (SELECT * FROM users)',
+        );
+    }
+
+    public function testItDoesBasicSort(): void
+    {
+        $sql = 'SELECT * FROM users ORDER BY users.a ASC';
+        $sort = $this->createMock(Sort::class);
+        $sort->method('getFields')->willReturn(['a']);
+        $sort->method('getPath')->with('a')->willReturn('users.a');
+        $sort->method('getDirection')->with('a')->willReturn('DESC');
+
+        $this->assertSame(
+            'SELECT * FROM users ORDER BY users.a DESC',
+            $this->applier->apply($sort, $sql),
+        );
+    }
+
+    public function testItDoesBasicSortWithPreExistingSort(): void
+    {
+        $sql = 'SELECT * FROM users ORDER BY users.name ASC';
+        $sort = $this->createMock(Sort::class);
+        $sort->method('getFields')->willReturn(['a']);
+        $sort->method('getPath')->with('a')->willReturn('users.a');
+        $sort->method('getDirection')->with('a')->willReturn('DESC');
+
+        $this->assertSame(
+            'SELECT * FROM users ORDER BY users.name ASC, users.a DESC',
+            $this->applier->apply($sort, $sql),
+        );
+    }
+
+    public function testItDoesTwoColumnsSortWithPreExistingSort(): void
+    {
+        $sql = 'SELECT * FROM users ORDER BY users.name ASC';
+        $sort = $this->createMock(Sort::class);
+        $sort->method('getFields')->willReturn(['a', 'c']);
+        $sort->method('getPath')->willReturnCallback(fn (string $f) => 'a' === $f ? 'users.a' : 'users.c');
+        $sort->method('getDirection')->willReturnCallback(fn (string $f) => 'a' === $f ? 'DESC' : 'ASC');
+
+        $this->assertSame(
+            'SELECT * FROM users ORDER BY users.name ASC, users.a DESC, users.c ASC',
+            $this->applier->apply($sort, $sql),
+        );
+    }
+
+    public function testItSortWithComplexPostgresQuery(): void
+    {
+        $sql = 'SELECT users.name, COUNT(users.id) FROM users INNER JOIN profile ON profile.user_id = users.id GROUP BY users.name ORDER BY ARRAY_POSITION(ARRAY[\'foo\', \'bar\', \'baz\'], users.name)';
+        $sort = $this->createMock(Sort::class);
+        $sort->method('getFields')->willReturn(['name']);
+        $sort->method('getPath')->with('name')->willReturn('ARRAY_POSITION(ARRAY[\'foo\', \'bar\', \'baz\'], users.name)');
+        $sort->method('getDirection')->with('name')->willReturn('DESC');
+
+        $this->assertSame(
+            'SELECT users.name, COUNT(users.id) FROM users INNER JOIN profile ON profile.user_id = users.id GROUP BY users.name ORDER BY ARRAY_POSITION(ARRAY[\'foo\', \'bar\', \'baz\'], users.name) DESC',
+            $this->applier->apply($sort, $sql),
+        );
+    }
+}

--- a/tests/Doc/Examples/BasicSqlSortTest.php
+++ b/tests/Doc/Examples/BasicSqlSortTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Sorter\Tests\Doc\Examples;
+
+use PHPUnit\Framework\TestCase;
+
+final class BasicSqlSortTest extends TestCase
+{
+    public function testItOutputsExpectedResult(): void
+    {
+        ob_start();
+        require __DIR__.'/../../../examples/basic-sql-sort.php';
+        $result = ob_get_clean();
+
+        $this->assertSame(file_get_contents(__FILE__, offset: __COMPILER_HALT_OFFSET__), $result);
+    }
+}
+
+__halt_compiler();
+
+ Default sort (Ascending date):
+ SELECT p, COUNT(p.comments) FROM post AS `p` INNER JOIN p.comments AS `comments` GROUP BY p.id ORDER BY p.date ASC
+
+
+ Single column sort (Ascending title):
+ SELECT p, COUNT(p.comments) FROM post AS `p` INNER JOIN p.comments AS `comments` GROUP BY p.id ORDER BY p.title ASC
+
+
+ Double column sort (Ascending Weight, Ascending title):
+ SELECT p, COUNT(p.comments) FROM post AS `p` INNER JOIN p.comments AS `comments` GROUP BY p.id ORDER BY p.weight ASC, p.title ASC


### PR DESCRIPTION
This PR adds an applier for plain text SQL.

It allow sorting native queries, without doctrine, for all standard SQL dialects, with or without orm / dbal.

Example :

```php
$sql = 'SELECT p, COUNT(p.comments) FROM post p INNER JOIN p.comments comments GROUP BY p.id';


$factory = new SorterFactory([new SqlApplier()]);
$sorter = $factory->createSorter()
    ->add('title', 'p.title')
    ->add('date', 'p.date')
    ->add('weight', 'p.weight')
    ->add('comments', 'COUNT(p.comments)')
    ->addDefault('date', Sort::ASC);


echo "\n\n Default sort (Ascending date):\n";
$sorter->handle([]);
$sql = $sorter->sort($sql);
echo " ", $sql, "\n";


echo "\n\n Single column sort (Ascending title):\n";
$sorter->handle(['title' => 'ASC']);
$sql = $sorter->sort($sql);
echo " ", $sql, "\n";


echo "\n\n Double column sort (Ascending Weight, Ascending title):\n";
$sorter->handle(['weight' => 'ASC', 'title' => 'ASC']);
$sql = $sorter->sort($sql);
echo " ", $sql, "\n";
```

Outputs : 

```
Default sort (Ascending date):
 SELECT p, COUNT(p.comments) FROM post AS `p` INNER JOIN p.comments AS `comments` GROUP BY p.id ORDER BY p.date ASC


 Single column sort (Ascending title):
 SELECT p, COUNT(p.comments) FROM post AS `p` INNER JOIN p.comments AS `comments` GROUP BY p.id ORDER BY p.title ASC


 Double column sort (Ascending Weight, Ascending title):
 SELECT p, COUNT(p.comments) FROM post AS `p` INNER JOIN p.comments AS `comments` GROUP BY p.id ORDER BY p.weight ASC, p.title ASC
```