### PR TITLE
Feature/add enum and object sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,28 @@ The twig extension provides the following functions:
 </table>
 
 ```
+
+### Object sorting with ArrayApplier
+
+By default, ArrayApplier use the PHP spaceship operator `<=>` to compare values. 
+With some objects, you may want to use a custom comparison function.
+
+You can use the `Comparable` interface to define a custom comparison function for your objects.
+
+```php
+
+final class CustomObject implements Comparable
+{
+    public function __construct(
+        public string $value1,
+        public string $value2,
+    ) {
+    }
+
+    public function compare(Comparable $other): int
+    {
+        return $this->value2 <=> $other->value2;
+    }
+}
+
+```php

--- a/examples/custom-object-sorting.php
+++ b/examples/custom-object-sorting.php
@@ -1,0 +1,71 @@
+<?php
+
+use Sorter\Applier\ArrayApplier;
+use Sorter\Comparable;
+use Sorter\SorterFactory;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * @template-implements Comparable<CustomObject>
+ */
+final class CustomObject implements Comparable
+{
+    public function __construct(
+        public string $value1,
+        public string $value2,
+    ) {
+    }
+
+    #[\Override]
+    public function compare(Comparable $other): int
+    {
+        return $this->value2 <=> $other->value2;
+    }
+}
+
+/**
+ * @param array{'object': CustomObject}[] $data
+ */
+function display_custom_object(array $data): void
+{
+    $horizontalLine = ' ---------------------' . PHP_EOL;
+
+    echo $horizontalLine;
+    echo ' | Value 1 | Value 2 |' . PHP_EOL;
+    echo $horizontalLine;
+
+    foreach ([...$data] as $row) {
+        echo
+            ' |  ' .
+            $row['object']->value1 . '     ' .
+            ' |  ' .
+            $row['object']->value2 . '     ' .
+            ' |' .
+            PHP_EOL;
+    }
+
+    echo $horizontalLine;
+}
+
+$factory = new SorterFactory([new ArrayApplier()]);
+$sorter = $factory->createSorter()
+    ->add('object', '[object]')
+    ->addDefault('object', 'ASC');
+
+
+$data = [
+    ['object' => new CustomObject('x', 'c')],
+    ['object' => new CustomObject('v', 'e')],
+    ['object' => new CustomObject('y', 'b')],
+    ['object' => new CustomObject('z', 'a')],
+    ['object' => new CustomObject('w', 'd')],
+];
+
+echo "\n";
+display_custom_object($data);
+
+$sorter->handle([]);
+$data = $sorter->sort($data);
+
+display_custom_object($data);

--- a/src/Applier/ArrayApplier.php
+++ b/src/Applier/ArrayApplier.php
@@ -44,6 +44,11 @@ final class ArrayApplier implements SortApplier
                     /** @var mixed $rightValue */
                     $rightValue = $this->propertyAccessor->getValue($right, $sort->getPath($field));
 
+                    if ($leftValue instanceof \BackedEnum && $rightValue instanceof \BackedEnum) {
+                        $leftValue = $leftValue->value;
+                        $rightValue = $rightValue->value;
+                    }
+
                     if ($leftValue > $rightValue) {
                         return Sort::ASC === $sort->getDirection($field) ? 1 : -1;
                     }

--- a/src/Applier/ArrayApplier.php
+++ b/src/Applier/ArrayApplier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sorter\Applier;
 
+use Sorter\Comparable;
 use Sorter\Exception\IncompatibleApplierException;
 use Sorter\Sort;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -43,6 +44,10 @@ final class ArrayApplier implements SortApplier
                     $leftValue = $this->propertyAccessor->getValue($left, $sort->getPath($field));
                     /** @var mixed $rightValue */
                     $rightValue = $this->propertyAccessor->getValue($right, $sort->getPath($field));
+
+                    if ($leftValue instanceof Comparable && $rightValue instanceof Comparable) {
+                        return (Sort::ASC === $sort->getDirection($field) ? 1 : -1) * $leftValue->compare($rightValue);
+                    }
 
                     if ($leftValue instanceof \BackedEnum && $rightValue instanceof \BackedEnum) {
                         $leftValue = $leftValue->value;

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sorter;
 
 /**
@@ -8,7 +10,7 @@ namespace Sorter;
 interface Comparable
 {
     /**
-     * @param Comparable<T> $other The object to compare with.
+     * @param Comparable<T> $other the object to compare with
      */
-    public function compare(Comparable $other): int;
+    public function compare(self $other): int;
 }

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -12,5 +12,5 @@ interface Comparable
     /**
      * @param T $other the object to compare with
      */
-    public function compare(Comparable $other): int;
+    public function compare(self $other): int;
 }

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -10,7 +10,7 @@ namespace Sorter;
 interface Comparable
 {
     /**
-     * @param Comparable<T> $other the object to compare with
+     * @param T $other the object to compare with
      */
-    public function compare(self $other): int;
+    public function compare(Comparable $other): int;
 }

--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sorter;
+
+/**
+ * @template T of Comparable
+ */
+interface Comparable
+{
+    /**
+     * @param Comparable<T> $other The object to compare with.
+     */
+    public function compare(Comparable $other): int;
+}

--- a/tests/Applier/ArrayApplierTest.php
+++ b/tests/Applier/ArrayApplierTest.php
@@ -7,6 +7,7 @@ namespace Sorter\Tests\Applier;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sorter\Applier\ArrayApplier;
+use Sorter\Comparable;
 use Sorter\Exception\IncompatibleApplierException;
 use Sorter\Sort;
 
@@ -79,7 +80,7 @@ final class ArrayApplierTest extends TestCase
     {
         $toBeSorted = [['enum' => SortableBackedEnum::B], ['enum' => SortableBackedEnum::A], ['enum' => SortableBackedEnum::C]];
 
-        $sort = new Sort;
+        $sort = new Sort();
         $sort->add('enum', '[enum]', 'ASC');
 
         $this->assertSame(
@@ -93,6 +94,28 @@ final class ArrayApplierTest extends TestCase
             (new ArrayApplier())->apply($sort, $toBeSorted),
         );
     }
+
+    public function testItSortObjectArray(): void
+    {
+        $a = new SortableObject('z', 'a');
+        $b = new SortableObject('y', 'b');
+        $c = new SortableObject('x', 'c');
+        $toBeSorted = [['object' => $b], ['object' => $a], ['object' => $c]];
+
+        $sort = new Sort();
+        $sort->add('object', '[object]', 'ASC');
+
+        $this->assertSame(
+            [['object' => $a], ['object' => $b], ['object' => $c]],
+            (new ArrayApplier())->apply($sort, $toBeSorted),
+        );
+
+        $sort->add('object', '[object]', 'DESC');
+        $this->assertSame(
+            [['object' => $c], ['object' => $b], ['object' => $a]],
+            (new ArrayApplier())->apply($sort, $toBeSorted),
+        );
+    }
 }
 
 enum SortableBackedEnum: string
@@ -100,4 +123,23 @@ enum SortableBackedEnum: string
     case A = 'a';
     case B = 'b';
     case C = 'c';
+}
+
+/**
+ * @extends Comparable<SortableObject>
+ */
+final class SortableObject implements Comparable
+{
+    public function __construct(public readonly string $value1, public readonly string $value2)
+    {
+    }
+
+    /**
+     * @param Comparable<self> $other
+     */
+    #[\Override]
+    public function compare(Comparable $other): int
+    {
+        return $this->value2 <=> $other->value2;
+    }
 }

--- a/tests/Applier/ArrayApplierTest.php
+++ b/tests/Applier/ArrayApplierTest.php
@@ -74,4 +74,30 @@ final class ArrayApplierTest extends TestCase
             (new ArrayApplier())->apply($sort, $toBeSorted)
         );
     }
+
+    public function testItSortEnumArray(): void
+    {
+        $toBeSorted = [['enum' => SortableBackedEnum::B], ['enum' => SortableBackedEnum::A], ['enum' => SortableBackedEnum::C]];
+
+        $sort = new Sort;
+        $sort->add('enum', '[enum]', 'ASC');
+
+        $this->assertSame(
+            [['enum' => SortableBackedEnum::A], ['enum' => SortableBackedEnum::B], ['enum' => SortableBackedEnum::C]],
+            (new ArrayApplier())->apply($sort, $toBeSorted),
+        );
+
+        $sort->add('enum', '[enum]', 'DESC');
+        $this->assertSame(
+            [['enum' => SortableBackedEnum::C], ['enum' => SortableBackedEnum::B], ['enum' => SortableBackedEnum::A]],
+            (new ArrayApplier())->apply($sort, $toBeSorted),
+        );
+    }
+}
+
+enum SortableBackedEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+    case C = 'c';
 }

--- a/tests/Applier/ArrayApplierTest.php
+++ b/tests/Applier/ArrayApplierTest.php
@@ -126,7 +126,7 @@ enum SortableBackedEnum: string
 }
 
 /**
- * @extends Comparable<SortableObject>
+ * @implements Comparable<SortableObject>
  */
 final class SortableObject implements Comparable
 {
@@ -134,9 +134,6 @@ final class SortableObject implements Comparable
     {
     }
 
-    /**
-     * @param Comparable<self> $other
-     */
     #[\Override]
     public function compare(Comparable $other): int
     {

--- a/tests/Doc/Examples/CustomObjectSortingTest.php
+++ b/tests/Doc/Examples/CustomObjectSortingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sorter\Tests\Doc\Examples;
+
+use PHPUnit\Framework\TestCase;
+
+final class CustomObjectSortingTest extends TestCase
+{
+    public function testItOutputsExpectedResult(): void
+    {
+        ob_start();
+        require __DIR__.'/../../../examples/custom-object-sorting.php';
+        $result = ob_get_clean();
+
+        $this->assertSame(file_get_contents(__FILE__, offset: __COMPILER_HALT_OFFSET__), $result);
+    }
+}
+
+__halt_compiler();
+ ---------------------
+ | Value 1 | Value 2 |
+ ---------------------
+ |  x      |  c      |
+ |  v      |  e      |
+ |  y      |  b      |
+ |  z      |  a      |
+ |  w      |  d      |
+ ---------------------
+ ---------------------
+ | Value 1 | Value 2 |
+ ---------------------
+ |  z      |  a      |
+ |  y      |  b      |
+ |  x      |  c      |
+ |  w      |  d      |
+ |  v      |  e      |
+ ---------------------


### PR DESCRIPTION
This PR adds two features to ArrayApplier :
 * Ability to sort BackedEnum (PHP spaceship operator `<=>` doesn't work on BackedEnum, while `sort` function do...)
 * Ability to custom sort Object (via the implementation of `Comparable` interface)